### PR TITLE
Fix: Handle client-side routing 404 on Vercel by adding vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  
-})
+  base: "/",
+  build: {
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
**Related Issue:** #264 

The app threw a 404 error when refreshing non-root routes (e.g., `/about`, `/dashboard`) on Vercel. This happened because Vercel attempted to resolve the URL path as a static file, not recognizing that React Router handles routing on the client side.

---

#### ✅ What does this PR do?

Adds a `vercel.json` configuration file to redirect all incoming routes to `index.html`, ensuring React Router can take over routing as expected.

---

#### 🧾 New file added

```json
// vercel.json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}
```

---

#### 🧾 Vite Config changed

```javascript
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react";

// https://vite.dev/config/
export default defineConfig({
  plugins: [react()],
+  base: "/",
+  build: {
+    outDir: "dist",
  },
});
```

---
#### 🔄 How to test

1. Deploy this branch to Vercel.
2. Navigate to a route like `/about` or `/trip`.
3. Refresh the page.
4. The correct React component should load, and no 404 should occur.

---
#### 🎥 Preview

https://github.com/user-attachments/assets/8ef85d49-8bf8-4452-aa7e-73a853a0dc71

---

#### 📌 Notes

This is a common configuration step for single-page apps (SPAs) using client-side routing frameworks like React Router.