### PR TITLE
Enabled SPA routing via rewrite on Vercel

### DIFF
--- a/Vercel.json
+++ b/Vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
To eliminate the 404 on deep links like /blog, we need to tell Vercel “serve index.html for every route” so that our client‑side router can take over.