### PR TITLE
Enable SPA routing via rewrite on Vercel

### DIFF
--- a/Vercel.json
+++ b/Vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,17 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-// https://vite.dev/config/
+// https://vitejs.dev/config/
 export default defineConfig({
+  // Enable React plugin for JSX and Fast Refresh support
   plugins: [react()],
-  
-})
+
+  // Base public path when served in production
+  base: "/",
+
+  // Build configuration
+  build: {
+    // Output directory for the production build
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
🐞 Issue Description
The application was returning a 404 Not Found error when refreshing or directly accessing non-root routes (e.g., /about, /blog, /trip) on Vercel.
This occurred because Vercel attempted to resolve the path as a static file, unaware that React Router handles routing on the client-side in this Single Page Application (SPA) setup.

✅ What Does This PR Do?
Adds a vercel.json configuration file to rewrite all routes to index.html, allowing React Router to correctly handle client-side routing.

Updates the Vite configuration with a proper base path and outDir to ensure smooth production builds.

🧾 Files Modified
➕ Added:
jsonc
Copy
Edit
// vercel.json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}
📝 Updated:
js
Copy
Edit
// vite.config.js
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react";

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [react()],
  // Ensures proper base path in production
  base: "/",
  build: {
    // Output directory for build artifacts
    outDir: "dist",
  },
});
🔄 How to Test
Deploy this branch to Vercel.

Open any route like /about, /blog, or /trip.

Refresh the page.

✅ Expected Result: Correct React component renders without a 404 error.

📌 Notes
This is a standard practice for SPAs using client-side routing like React Router.
Without this configuration, Vercel treats non-root paths as missing static files, leading to 404 errors on refresh.

