### PR TITLE
Fix: Move sidebar below header such that toggle button works

### DIFF
--- a/src/components/nav.jsx
+++ b/src/components/nav.jsx
@@ -67,8 +67,8 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
 
   return (
     <>
-      <div className="bg-blue-900 text-white py-2 hidden md:block">
-        <div className="container mx-auto px-4 flex justify-between items-center text-sm">
+      <div className="hidden py-2 text-white bg-blue-900 md:block">
+        <div className="container flex items-center justify-between px-4 mx-auto text-sm">
           <div className="flex items-center space-x-4">
             <span className="flex items-center">
               <Phone className="w-4 h-4 mr-1" />
@@ -103,16 +103,16 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
           isScrolled ? 'shadow-lg bg-white' : 'bg-white/95'
         } transition-all duration-300`}
       >
-        <div className="container mx-auto px-4">
-          <div className="flex justify-between items-center h-16">
+        <div className="container px-4 mx-auto">
+          <div className="flex items-center justify-between h-16">
             <Link to="/" className="flex items-center space-x-2">
               <img src={Logo} alt="Haryana Roadways Logo" className="w-8 h-8" />
-              <span className="font-bold text-xl text-blue-900">
+              <span className="text-xl font-bold text-blue-900">
                 Haryana Roadways
               </span>
             </Link>
 
-            <div className="hidden md:flex items-center space-x-8">
+            <div className="items-center hidden space-x-8 md:flex">
               <Link to="/" className="nav-link">
                 {currentLanguage.home}
               </Link>
@@ -122,7 +122,7 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
                 onMouseEnter={() => setIsServicesOpen(true)}
                 onMouseLeave={() => setIsServicesOpen(false)}
               >
-                <button className="nav-link flex items-center">
+                <button className="flex items-center nav-link">
                   {currentLanguage.services}
                   <ChevronDown className="w-4 h-4 ml-1" />
                 </button>
@@ -155,14 +155,14 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
                 {currentLanguage.donate}
               </Link>
 
-              <button className="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-900 transition flex items-center">
+              <button className="flex items-center px-4 py-2 text-white transition bg-blue-800 rounded-lg hover:bg-blue-900">
                 <Phone className="w-4 h-4 mr-2" />
                 <Link to="/helpline">{currentLanguage.helpline}</Link>
               </button>
             </div>
 
             <button
-              className="md:hidden text-blue-900"
+              className="text-blue-900 md:hidden"
               onClick={toggleSidebar}
             >
               {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
@@ -171,7 +171,7 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
         </div>
       </nav>
 
-      <div className={`sidebar ${isMobileMenuOpen ? 'open' : ''}`}>
+      <div className={`sidebar md:hidden ${isMobileMenuOpen ? 'open' : ''}`}>
         <ul>
           <li>
             <Link to="/" onClick={toggleSidebar}>

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -191,7 +191,7 @@ a.nav-link:hover {
 
 .sidebar {
   position: fixed;
-  top: 0;
+  /* top: 0; */
   right: 0;
   width: 100%; /* Make sidebar full width on mobile screens */
   height: 100%;
@@ -200,7 +200,7 @@ a.nav-link:hover {
   transform: translateX(100%);
   transition: transform 0.3s;
   z-index: 1001;
-  padding-top: 60px; /* To ensure it does not overlap with the nav bar */
+  /* padding-top: 60px; To ensure it does not overlap with the nav bar */
   color: white;
 }
 


### PR DESCRIPTION
# Pull Request: Make Sidebar Toggle Workable by Shifting Sidebar Below Header
## Description
This PR improves the responsiveness and functionality of the sidebar toggle button by repositioning the sidebar and updating its visibility logic. The main issue addressed was the sidebar overlapping with the header and the toggle button, particularly in mobile view. This is regarding issue #272  

## Changes Made
1. Hide Sidebar on Larger Screens (nav.jsx)
- Adjusted the sidebar visibility to be hidden on larger screens where both the top nav and sidebar were previously shown simultaneously (in tablet view).
- Ensures a cleaner UI on tablets and improves layout consistency.

2. Reposition Sidebar Below Header
- Changed the positioning logic so the sidebar now appears beneath the header instead of overlapping it.
- Resolves layout conflicts and improves accessibility.

3. Fix Sidebar Toggle Functionality
- Since the sidebar no longer overlaps the toggle button, the button can now reliably open and close the sidebar.
- Toggle behavior is now consistent across different screen sizes.

## Testing
1. Verified functionality on multiple screen sizes: desktop, tablet, and mobile.
2. Sidebar opens and closes correctly via the toggle button.
3. No layout overlap between sidebar and header or toggle button.

## Screen Recording:

https://github.com/user-attachments/assets/cac7f42a-62a7-441d-8e53-7331edf3f651
