### PR TITLE
Fix: Badges added on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <h1 align="center">HrRoadways</h1>
+<p align="center">
+  <img src="https://img.shields.io/badge/BUILD-grey?style=for-the-badge" />
+  <img src="https://img.shields.io/badge/PASSING-brightgreen?style=for-the-badge" />
+  <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=61DAFB&style=for-the-badge" />
+</p>
+
 <h4 align="center">
   HrRoadways is a comprehensive project designed to provide users with an intuitive platform to check bus routes, timings, and real-time updates for government bus services.
 </h4>


### PR DESCRIPTION
resolves #295 
Added **Build,** **Passing** and **React** badge on the Readme to make it look more professional
<img width="1391" height="411" alt="image" src="https://github.com/user-attachments/assets/605a9ef3-1888-48ba-981d-b26ebb9215d7" />
