### PR TITLE
fix(nav): stabilize “Services” dropdown hover with 200ms delay

### DIFF
--- a/src/components/nav.jsx
+++ b/src/components/nav.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/nav.css';
 import { Menu, X, ChevronDown, Phone } from 'lucide-react';
@@ -7,10 +7,39 @@ import { getStoredLanguage, setStoredLanguage } from '../../libs/languageStorage
 const Logo = 'https://i.ibb.co/kg3RQQ1S/LogoHR.png';
 
 const Navigation = ({ isHindi, onToggleLanguage }) => {
+  // ─── State Hooks ───────────────────────────────────────
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isServicesOpen, setIsServicesOpen] = useState(false);
 
+  // ─── Ref for the dropdown timer ───────────────────────
+  const servicesTimer = useRef(null);
+
+  // ─── Scroll listener ──────────────────────────────────
+  useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // ─── Dropdown hover handlers ──────────────────────────
+  const handleMouseEnter = () => {
+    clearTimeout(servicesTimer.current);
+    setIsServicesOpen(true);
+  };
+
+  const handleMouseLeave = () => {
+    servicesTimer.current = setTimeout(() => {
+      setIsServicesOpen(false);
+    }, 200);
+  };
+
+  // ─── Language persistence ─────────────────────────────
+  useEffect(() => {
+    setStoredLanguage(isHindi ? 'hi' : 'en');
+  }, [isHindi]);
+
+  // ─── Translations & Links ─────────────────────────────
   const translations = {
     en: {
       home: "Home",
@@ -26,7 +55,7 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
       blog: "Blog",
       quickLinks: "Quick Links",
       travellocations: "Travel",
-      guide: "Guide and Rules"
+      guide: "Guide and Rules",
     },
     hi: {
       home: "मुख्य पृष्ठ",
@@ -42,21 +71,10 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
       blog: "ब्लॉग",
       quickLinks: "त्वरित लिंक",
       travellocations: "यात्रा",
-      guide: "मार्गदर्शिका और नियम"
+      guide: "मार्गदर्शिका और नियम",
     },
   };
-
   const currentLanguage = isHindi ? translations.hi : translations.en;
-
-  useEffect(() => {
-    setStoredLanguage(isHindi ? 'hi' : 'en');
-  }, [isHindi]);
-
-  useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 50);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const servicesDropdown = [
     { title: currentLanguage.track, path: '/track' },
@@ -64,7 +82,7 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
     { title: currentLanguage.tourGuide, path: '/tour-guide' },
   ];
 
-  const toggleSidebar = () => setIsMobileMenuOpen(!isMobileMenuOpen);
+  const toggleSidebar = () => setIsMobileMenuOpen(x => !x);
 
   return (
     <>
@@ -102,33 +120,51 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
       </div>
 
       {/* Navbar */}
-      <nav className={`sticky top-0 z-50 w-full ${isScrolled ? 'shadow-lg bg-white' : 'bg-white/95'} transition-all duration-300`}>
+      <nav
+        className={`sticky top-0 z-50 w-full ${
+          isScrolled ? 'shadow-lg bg-white' : 'bg-white/95'
+        } transition-all duration-300`}
+      >
         <div className="container mx-auto px-4">
           <div className="flex justify-between items-center h-16">
             <Link to="/" className="flex items-center space-x-2">
               <img src={Logo} alt="Haryana Roadways Logo" className="w-8 h-8" />
-              <span className="text-xl font-bold text-blue-900">Haryana Roadways</span>
+              <span className="text-xl font-bold text-blue-900">
+                Haryana Roadways
+              </span>
             </Link>
 
             {/* Desktop Links */}
             <div className="hidden md:flex items-center space-x-6">
-              <Link to="/" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.home}
               </Link>
 
               <div
-                className="relative group"
-                onMouseEnter={() => setIsServicesOpen(true)}
-                onMouseLeave={() => setIsServicesOpen(false)}
+                className="relative"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
               >
                 <button className="text-gray-700 hover:text-blue-600 font-medium flex items-center">
                   {currentLanguage.services}
-                  <ChevronDown className="w-4 h-4 ml-1 transition-transform duration-200 group-hover:rotate-180" />
+                  <ChevronDown
+                    className={`w-4 h-4 ml-1 transition-transform duration-200 ${
+                      isServicesOpen ? 'rotate-180' : ''
+                    }`}
+                  />
                 </button>
-                <div className={`absolute top-full left-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-10 ${isServicesOpen ? 'block' : 'hidden'}`}>
-                  {servicesDropdown.map((item, index) => (
+
+                <div
+                  className={`absolute top-full left-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-10 ${
+                    isServicesOpen ? 'block' : 'hidden'
+                  }`}
+                >
+                  {servicesDropdown.map((item, idx) => (
                     <Link
-                      key={index}
+                      key={idx}
                       to={item.path}
                       className="block px-4 py-2 text-gray-700 hover:bg-blue-50 hover:text-blue-600"
                       onClick={() => setIsServicesOpen(false)}
@@ -139,23 +175,41 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
                 </div>
               </div>
 
-              <Link to="/trip" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/trip"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.trip}
               </Link>
-              <Link to="/travellocations" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/travellocations"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.travellocations}
               </Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/about"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.about}
               </Link>
-              <Link to="/blog" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/blog"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.blog}
               </Link>
-              <Link to="/donate" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link
+                to="/donate"
+                className="text-gray-700 hover:text-blue-600 font-medium"
+              >
                 {currentLanguage.donate}
               </Link>
 
-              <Link to="/helpline" className="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition flex items-center text-base font-semibold ml-4">
+              <Link
+                to="/helpline"
+                className="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition flex items-center text-base font-semibold ml-4"
+              >
                 <Phone className="w-4 h-4 mr-1" />
                 {currentLanguage.helpline}
               </Link>
@@ -167,30 +221,50 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
               onClick={toggleSidebar}
               aria-label="Toggle menu"
             >
-              {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+              {isMobileMenuOpen ? (
+                <X className="w-6 h-6" />
+              ) : (
+                <Menu className="w-6 h-6" />
+              )}
             </button>
           </div>
         </div>
       </nav>
 
       {/* Mobile Sidebar */}
-      <div className={`fixed inset-y-0 right-0 w-64 bg-white shadow-lg transform ${isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'} transition-transform duration-300 ease-in-out z-50 md:hidden`}>
+      <div
+        className={`fixed inset-y-0 right-0 w-64 bg-white shadow-lg transform ${
+          isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
+        } transition-transform duration-300 ease-in-out z-50 md:hidden`}
+      >
         <div className="p-4">
           <ul className="space-y-4">
-            <li><Link to="/" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.home}</Link></li>
+            <li>
+              <Link
+                to="/"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.home}
+              </Link>
+            </li>
 
             <li className="relative">
               <button
-                onClick={() => setIsServicesOpen(!isServicesOpen)}
+                onClick={() => setIsServicesOpen(x => !x)}
                 className="block py-2 hover:text-blue-600 flex items-center justify-between w-full"
               >
                 {currentLanguage.services}
-                <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isServicesOpen ? 'rotate-180' : ''}`} />
+                <ChevronDown
+                  className={`w-4 h-4 transition-transform duration-200 ${
+                    isServicesOpen ? 'rotate-180' : ''
+                  }`}
+                />
               </button>
               {isServicesOpen && (
                 <ul className="ml-4 mt-1 space-y-2">
-                  {servicesDropdown.map((item, index) => (
-                    <li key={index}>
+                  {servicesDropdown.map((item, idx) => (
+                    <li key={idx}>
                       <Link
                         to={item.path}
                         className="block px-4 py-2 text-gray-700 hover:bg-blue-50 hover:text-blue-600"
@@ -204,12 +278,60 @@ const Navigation = ({ isHindi, onToggleLanguage }) => {
               )}
             </li>
 
-            <li><Link to="/trip" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.trip}</Link></li>
-            <li><Link to="/travellocations" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.travellocations}</Link></li>
-            <li><Link to="/about" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.about}</Link></li>
-            <li><Link to="/blog" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.blog}</Link></li>
-            <li><Link to="/donate" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.donate}</Link></li>
-            <li><Link to="/helpline" onClick={toggleSidebar} className="block py-2 hover:text-blue-600">{currentLanguage.helpline}</Link></li>
+            <li>
+              <Link
+                to="/trip"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.trip}
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/travellocations"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.travellocations}
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/about"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.about}
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/blog"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.blog}
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/donate"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.donate}
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/helpline"
+                onClick={toggleSidebar}
+                className="block py-2 hover:text-blue-600"
+              >
+                {currentLanguage.helpline}
+              </Link>
+            </li>
 
             <li className="flex items-center justify-between py-2">
               <span>EN</span>


### PR DESCRIPTION
📄 Description
This PR stabilizes the “Services” dropdown in the desktop navigation by introducing a small delay before hiding the menu. Previously, rapid cursor movements between the “Services” button and its submenu would trigger an immediate close, making it impossible to click any of the submenu links. We now:

Add a servicesTimer ref to manage the hide timeout.

Implement handleMouseEnter to clear any pending hide timer and open the dropdown immediately.

Implement handleMouseLeave to set a 200 ms timer before hiding the dropdown.

Preserve all existing scroll‑and‑language logic and CSS classes.

🧩 Related Issue
Closes #305  — “Services” dropdown flickers and disappears on hover

✅ TODOs
 Code review

 Verify behavior across major browsers

 Add unit test for hover‑delay logic (optional)

 Update any relevant documentation

