### PR TITLE
Fix: Add missing Navigate import and remove duplicate CSS @import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import Navigation from './components/nav';
 import Hero from './components/hero';
 import Available from './components/Available';

--- a/src/styles/luxury.css
+++ b/src/styles/luxury.css
@@ -229,7 +229,6 @@
 .destination-card:hover {
     animation: royalGlow 1.5s infinite alternate;
 }
-@import url('https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&family=Cormorant+Garamond:wght@300;400;700&display=swap');
 
 :root {
     --royal-blue: #1a5f7a;


### PR DESCRIPTION
- Added Navigate import to App.jsx to fix ReferenceError: Navigate is not defined
- Removed duplicate @import statement in luxury.css causing PostCSS build error

These fixes resolve runtime errors preventing the application from starting properly.

## 📄 Description

<!-- Provide a clear and concise description of the changes in this PR. -->

## 🧩 Related Issue

<!-- Link the issue this PR addresses -->
Closes #[Issue Number]

## 📸 Evidence

<!-- Show proof of the implementation working (e.g., screenshots, test logs, contracts deployed, etc.) -->
- [ ] Added unit tests
- [ ] Manual testing steps
- [ ] Other evidence (logs/screenshots/etc)

## ✅ TODOs

<!-- List any pending items related to this PR or anything for the reviewer to know -->
- [ ] Code review
- [ ] Final test cases
- [ ] Documentation (if needed)
- [ ] Deployment plan (if needed)

## 🔍 Checklist before merging

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
