### PR TITLE
Fixes the spelling error of name and registser

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -33,7 +33,7 @@
   
   "register": {
     "title": "Register",
-    "namePlaceholder": "Enter your ame...",
+    "namePlaceholder": "Enter your name...",
     "emailPlaceholder": "Enter your email...",
     "passwordPlaceholder": "Enter your password...",
     "button": "Register",
@@ -46,7 +46,7 @@
     "passwordPlaceholder": "Enter your password...",
     "button": "Login",
     "prompt": "Don't have an account?",
-    "registerLink": "Regist er",
+    "registerLink": "Register",
     "forgotPassword": "Forgot Password?"
   },
   "forgotPassword": {


### PR DESCRIPTION
## 📄 Description

Corrected the spelling of "Register and Name" in the component, modal type, and translation keys. This resolves minor UI inconsistencies and improves clarity across the login/register modal.

## 🧩 Related Issue
Closes #433

## 📸 Evidence

<img width="948" height="1080" alt="Screenshot (206)" src="https://github.com/user-attachments/assets/e312b638-8d46-444f-9adc-03b506b9f553" />

<img width="968" height="1080" alt="Screenshot (207)" src="https://github.com/user-attachments/assets/d581a9ad-73b2-4e24-8e1e-015c1476143f" />



## 🔍 Checklist before merging

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- My changes generate no new warnings or errors
