### PR TITLE
Fixed the text color under 'Best Rides' page 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,13 +1982,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -6902,9 +6902,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/BestRides.jsx
+++ b/src/components/BestRides.jsx
@@ -312,10 +312,10 @@ const BestRides = () => {
         <div className="absolute inset-0 bg-black opacity-50"></div>
         <div className="relative max-w-7xl mx-auto px-4 h-full flex items-center pb-8"> {/* Added padding-bottom */}
           <div className="text-black">
-            <h1 className="text-5xl font-bold mb-4">
+            <h1 className="text-5xl font-bold mb-4 text-white">
               Experience Premium Travel
             </h1>
-            <p className="text-xl mb-8">Discover why our premium routes offer the best travel experience in Haryana</p>
+            <p className="text-xl mb-8 text-blue-200">Discover why our premium routes offer the best travel experience in Haryana</p>
             <button 
               onClick={() => setShowFleetModal(true)}
               className="bg-blue-600 text-white px-8 py-3 rounded-full flex items-center space-x-2 hover:bg-blue-700 transition-all"


### PR DESCRIPTION
The text color of the **'title'** and **'caption'** has been given two different colors, which can make the page look much more appealing.

Changes included
✅ The text color of the **'title'** is now changed to **white**
✅ The text color of the **'caption'** has been changed to **blue-200**

I've attached the relevant screenshot of my work for your reference. I request you to review it. Thank you. 

<img width="1597" height="903" alt="image" src="https://github.com/user-attachments/assets/d90ece6f-e057-4552-89db-bc9558e963ee" />
 